### PR TITLE
Use raw strings for regex.

### DIFF
--- a/vbuild/__init__.py
+++ b/vbuild/__init__.py
@@ -227,8 +227,8 @@ def mkPrefixCss(css, prefix=""):
         medias.append((mediadef, mkPrefixCss(mediacss, prefix)))
 
     lines = []
-    css = re.sub(re.compile("/\*.*?\*/", re.DOTALL), "", css)
-    css = re.sub(re.compile("[ \t\n]+", re.DOTALL), " ", css)
+    css = re.sub(re.compile(r"/\*.*?\*/", re.DOTALL), "", css)
+    css = re.sub(re.compile(r"[ \t\n]+", re.DOTALL), " ", css)
     for rule in re.findall(r"[^}]+{[^}]+}", css):
         sels, decs = rule.split("{", 1)
         if prefix:


### PR DESCRIPTION
Modern python (3.10 in my case) raises `DeprecationWarning` for some regex strings mistaking regex expressions for escape sequences.

This PR fixes it by converting strings into raw strings.

Warning example:

```python
/workspace/.venv/lib/python3.10/site-packages/vbuild/__init__.py:230: DeprecationWarning: invalid escape sequence '\*'
  css = re.sub(re.compile("/\*.*?\*/", re.DOTALL), "", css)
```

