### PR TITLE
Fix the deprecation warning on pktutil #14

### DIFF
--- a/vbuild/__init__.py
+++ b/vbuild/__init__.py
@@ -9,7 +9,7 @@
 # #############################################################################
 __version__ = "0.0.0" # auto-updated
 
-import re, os, json, glob, itertools, traceback, subprocess, pkgutil
+import re, os, json, glob, itertools, traceback, subprocess
 
 try:
     from HTMLParser import HTMLParser
@@ -30,9 +30,9 @@ fullPyComp = True  # 3 states ;-)
 # False : minimal py comp, vbuild will include the std lib
 # True  : each component generate its needs (default)
 
-hasLess = bool(pkgutil.find_loader("lesscpy"))
-hasSass = bool(pkgutil.find_loader("scss"))
-hasClosure = bool(pkgutil.find_loader("closure"))
+hasLess = bool(importlib.util.find_spec("lesscpy"))
+hasSass = bool(importlib.util.find_spec("scss"))
+hasClosure = bool(importlib.util.find_spec("closure"))
 
 
 class VBuildException(Exception):

--- a/vbuild/__init__.py
+++ b/vbuild/__init__.py
@@ -9,7 +9,7 @@
 # #############################################################################
 __version__ = "0.0.0" # auto-updated
 
-import re, os, json, glob, itertools, traceback, subprocess
+import re, os, json, glob, itertools, traceback, subprocess, importlib
 
 try:
     from HTMLParser import HTMLParser


### PR DESCRIPTION
This PR fixes #14 

From python3.12/pkgutil.py:

```python
warnings._deprecated(
    "pkgutil.find_loader",
    f"{warnings._DEPRECATED_MSG}; "
    "use importlib.util.find_spec() instead",
    remove=(3, 14)
)
```